### PR TITLE
Polish README and JS example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ cluster/socket
 examples/purescript-example/.spago
 examples/purescript-example/output
 examples/purescript-example/node_modules
+examples/js-example/data
 secrets
 .ipynb_checkpoints
 *.pkl
+
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # congested-testnet
-The goal of this project is to operate a cardano testnet under constant congestion. Therefore, an additional component, a spammer, is included. This component continuously generates transactions to simulate periods of congestion commonly observed on the mainnet.
+The goal of this project is to operate a cardano testnet under constant congestion. To achieve this, an additional **spammer** component has been added. This component continuously generates transactions to simulate periods of congestion commonly observed on the mainnet.
 
 - [Congestion research](./docs/congestion-statistics.md)
 - [Design](./docs/design.md)
 - [How to use](#how-to-use)
+
 ## How to Use
 
 The **Genesis SPO node** with a spammer, which simulates network congestion, is running on the server [`congested-testnet.staging.mlabs.city`](http://congested-testnet.staging.mlabs.city) on the following ports:
@@ -13,23 +14,34 @@ The **Genesis SPO node** with a spammer, which simulates network congestion, is 
 - `1337` – Ogmios  
 - `5000` – Shared testnet configuration files for running a custom node  
 
-<!-- #### Submitting Custom Transactions -->
+### Submittig Transactions to the Testnet
 
-You can submit custom transactions **without running a local node**. This process is demonstrated in the [`cardano-cli-nodejs` example](./examples/get-ada-submit-tx.js). Additionally, you will find examples on how to request **Faucet, Ogmios, and Kupo**.  
+You can submit custom transactions **without running a local node**. This process is demonstrated in the [`js-example`](./examples/js-example/get-ada-submit-tx.js). It demonstrates the following:
+1. Withdrawing funds from the **Faucet**.
+2. Submitting a tx through **Ogmios**.
+3. Checking when the tx appears on chain with **Kupo**.  
 
-To follow these examples, ensure you have `nodejs` and `docker` installed. 
+To run the JS example, you will first need to have `nodejs` and `docker` installed.
+
+You will also need `cardano-node` and `cardano-cli` running:
 
 ```bash
 alias cardano-node="docker run --rm -it -v $(pwd):/workspace ghcr.io/intersectmbo/cardano-node:10.4.1 /bin/cardano-node"
 alias cardano-cli="docker run --rm -it -v $(pwd):/workspace ghcr.io/intersectmbo/cardano-node:10.4.1 /bin/cardano-cli"
-npm i node-fetch
-node examples/get-ada-submit-tx.js
-
 ```  
 
-You can also run your own Genesis SPO node with Ogmios, Kupo, Faucet, Share Config, and Prometheus Metrics, and simulate congestion using Spammer. It is worth mentioning that we can regulate congestion using the MEMPOOL_PAUSE_LIMIT (max 1_000_000 bytes). This means, the Spammer will run until the mempool reaches the target value.
+Use the following commands to run the example:
+```bash
+cd examples/js-example
+npm install
+node .
+```
 
-It is possible that the cardano-node on your machine outpaces the Spammer, and you want to simulate higher congestion. In this case, we can reduce the block size, increase the slotLength, or both.
+## Running the Congested Testnet
+
+You can also run your own Genesis SPO node with Ogmios, Kupo, Faucet, Share Config, and Prometheus Metrics, and simulate congestion using Spammer. It is worth mentioning that you can regulate congestion using the MEMPOOL_PAUSE_LIMIT (max 1_000_000 bytes). This means, the Spammer will run until the mempool reaches the target value.
+
+It is possible that the cardano-node on your machine outpaces the Spammer, and you want to simulate higher congestion. In this case, you can reduce the block size, increase the slotLength, or both.
 
 ```bash
 git clone https://github.com/mlabs-haskell/congested-testnet
@@ -47,10 +59,8 @@ SPO_ADDRESS=http://congested-testnet.staging.mlabs.city docker-compose --profile
 ```
 All configs are available on `http://congested-testnet.staging.mlabs.city:5000`. So you can run your own node  
 
-
-
-### faucet
-To obtain tADA, we need to submit a public key through an HTTP query. This will provide us with 1000 ADA
+### Faucet
+To obtain tADA, you can submit a public key through an HTTP query. This will provide you with 1000 ADA.
 ```bash
 
 # we can generate key pairs with cardano-cli
@@ -67,22 +77,24 @@ PUBKEYHASHHEX=$(cardano-cli address key-hash --payment-verification-key-file "ke
 # now get ada with query
 curl -X POST "congested-testnet.staging.mlabs.city:8000" -H "Content-Type: application/json" -d "{\"pubKeyHashHex\": \"$PUBKEYHASHHEX\"}"
 ```
-this part can be executed using [nix flakes](https://nixos.wiki/wiki/Flakes) inside current repo `nix run .#get-tada`
+This part can be executed using [nix flakes](https://nixos.wiki/wiki/Flakes) inside current repo `nix run .#get-tada`
 
-### submit transactions 
-To submit a transaction on the testnet, we can use [ogmios](https://github.com/CardanoSolutions/ogmios) and [kupo](https://github.com/CardanoSolutions/kupo). For this, you can use cardano-cli with http requests, like in [`cardano-cli-nodejs` example](./examples/get-ada-submit-tx.js). Additionally there are offchain libraries like [purescript CTL](https://github.com/Plutonomicon/cardano-transaction-lib), [ogmios clients and tx examples](https://ogmios.dev/clients/) available in other languages. Whichever client you choose to use, simply use next addresses `congested-testnet.staging.mlabs.city:1337` and `congested-testnet.staging.mlabs.city:1442`
+### Submit Transactions 
+To submit a transaction on the testnet, you can use [ogmios](https://github.com/CardanoSolutions/ogmios) and [kupo](https://github.com/CardanoSolutions/kupo). For this, you can use cardano-cli with http requests, like in [`cardano-cli-nodejs` example](./examples/js-example/get-ada-submit-tx.js). Additionally there are offchain libraries like [purescript CTL](https://github.com/Plutonomicon/cardano-transaction-lib), [ogmios clients and tx examples](https://ogmios.dev/clients/) available in other languages. Whichever client you choose to use, simply use following addresses:
+- `congested-testnet.staging.mlabs.city:1337` for Ogmios
+- `congested-testnet.staging.mlabs.city:1442` for Kupo
 
-### verify transaction
-We can verify that the transaction is on the ledger with kupo.
+### Verify Transaction
+You can verify that the transaction is on the ledger with kupo.
 ```
 curl http://congested-testnet.staging.mlabs.city:1442/matches/*@<transactionHash>
 ```
 
-### tests 
-We can run bats tests using `nix run .#tests`. Additionally, we can monitor Cardano testnet statistics with [prometheus-db](http://congested-testnet.staging.mlabs.city:9090). We can find in Prometheus `await_time_tx` metrics which measure verify transaction time for simple transaction.
+### Tests 
+You can run bats tests using `nix run .#tests`. Additionally, you can monitor the Cardano testnet statistics with [prometheus-db](http://congested-testnet.staging.mlabs.city:9090). You can find `await_time_tx` in the Prometheus metrics which measure verify transaction time for simple transaction.
 
 
-### deployment
+### Deployment
 Run
 
 ```bash

--- a/examples/js-example/package-lock.json
+++ b/examples/js-example/package-lock.json
@@ -1,0 +1,144 @@
+{
+  "name": "congested-testnet-js-example",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "congested-testnet-js-example",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "node-fetch": "^3.3.2"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  },
+  "dependencies": {
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
+    "node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "requires": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      }
+    },
+    "web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
+    }
+  }
+}

--- a/examples/js-example/package.json
+++ b/examples/js-example/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "congested-testnet-js-example",
+  "version": "1.0.0",
+  "description": "",
+  "type":"module",
+  "main": "get-ada-submit-tx.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "node-fetch": "^3.3.2"
+  }
+}


### PR DESCRIPTION
This polishes the README file for additional clarity. It also restructures the JS example so that it uses package.json for installing the `node-fetch` dependency, and keeps all generated files in a single subfolder.